### PR TITLE
Feature/performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ public function registerSchematicFieldModels()
 ## Changelog
 
 ###3.1.1###
+ - Sections are not imported when nothing has changed
+ - Fields are not imported when nothing has changed
+ - Field import is repeated after everything else has been imported to make sure sources are set correctly
+
+###3.1.1###
  - Folders are now CamelCased to add support for case-sensitive systems and PSR-4 (thanks to @ostark and @ukautz)
 
 ###3.1.0###

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ public function registerSchematicFieldModels()
 
 ## Changelog
 
-###3.1.1###
+###3.1.2###
  - Sections are not imported when nothing has changed
  - Fields are not imported when nothing has changed
  - Field import is repeated after everything else has been imported to make sure sources are set correctly

--- a/src/Services/Fields.php
+++ b/src/Services/Fields.php
@@ -292,6 +292,14 @@ class Fields extends Base
         foreach ($fieldDefinitions as $fieldHandle => $fieldDef) {
             $field = $this->getFieldModel($fieldHandle);
             $schematicFieldModel = $fieldFactory->build($fieldDef['type']);
+
+            if ($schematicFieldModel->getDefinition($field, true) === $fieldDef ) {
+                Craft::log(Craft::t('Skipping `{name}`, no changes detected', ['name' => $field->name]));
+                continue;
+            }
+
+            Craft::log(Craft::t('Importing `{name}`', ['name' => $fieldDef['name']]));
+
             $schematicFieldModel->populate($fieldDef, $field, $fieldHandle, $group);
             $this->saveFieldModel($field);
         }

--- a/src/Services/Schematic.php
+++ b/src/Services/Schematic.php
@@ -100,6 +100,7 @@ class Schematic extends BaseApplication
         $sectionImportResult = Craft::app()->schematic_sections->import($model->getAttribute('sections'), $force);
         $userGroupImportResult = Craft::app()->schematic_userGroups->import($model->getAttribute('userGroups'), $force);
         $userImportResult = Craft::app()->schematic_users->import($model->getAttribute('users'), true);
+        $fieldImportResultFinal = Craft::app()->schematic_fields->import($model->getAttribute('fields'), $force);
 
         // Element index settings are supported from Craft 2.5
         if (version_compare(CRAFT_VERSION, '2.5', '>=')) {
@@ -116,6 +117,7 @@ class Schematic extends BaseApplication
         $result->consume($sectionImportResult);
         $result->consume($userGroupImportResult);
         $result->consume($userImportResult);
+        $result->consume($fieldImportResultFinal);
 
         // Element index settings are supported from Craft 2.5
         if (version_compare(CRAFT_VERSION, '2.5', '>=')) {

--- a/src/Services/Sections.php
+++ b/src/Services/Sections.php
@@ -158,6 +158,11 @@ class Sections extends Base
 
             unset($sections[$sectionHandle]);
 
+            if($sectionDefinition === $this->getSectionDefinition($section, null)){
+                Craft::log(Craft::t('Skipping `{name}`, no changes detected', ['name' => $section->name]));
+                continue;
+            }
+
             if (!array_key_exists('locales', $sectionDefinition)) {
                 $this->addError('`sections[handle].locales` must be defined');
 
@@ -169,6 +174,8 @@ class Sections extends Base
 
                 continue;
             }
+
+            Craft::log(Craft::t('Importing section `{name}`', ['name' => $sectionDefinition['name']]));
 
             $this->populateSection($section, $sectionDefinition, $sectionHandle);
 


### PR DESCRIPTION
Don't import fields and sections when nothing has changed to prevent a million resaveElement tasks spawning.
Repeat field import at the end to make sure all sources are set correctly.
