### PR TITLE
Fixed error when trying to register event for unknown component

### DIFF
--- a/src/Console/App.php
+++ b/src/Console/App.php
@@ -162,7 +162,9 @@ class App extends Base
             $eventName = 'on'.ucfirst($eventName);
         }
 
-        $component->$eventName = $handler;
+        if ($component !== null) {
+            $component->$eventName = $handler;
+        }
     }
 
     /**


### PR DESCRIPTION
Some plugin will register event handler in there init method. These init methods are called during an import or export when the plugin is enabled and this will cause an error.
For example the Sprout Invisible Captcha plugin:

`
PHP Error[2]: Creating default object from empty value
    in file /var/www/vendor/itmundi/schematic/src/Console/App.php at line 166
#0 /var/www/vendor/itmundi/schematic/src/Console/App.php(240): NerdsAndCompany\Schematic\Console\App->handleError()
#1 /var/www/vendor/itmundi/schematic/src/Console/App.php(166): NerdsAndCompany\Schematic\Console\App->handleError()
#2 /var/www/craft/plugins/sproutinvisiblecaptcha/SproutInvisibleCaptchaPlugin.php(199): NerdsAndCompany\Schematic\Console\App->on()
#3 /var/www/craft/app/services/PluginsService.php(152): Craft\SproutInvisibleCaptchaPlugin->init()
#4 /var/www/vendor/itmundi/schematic/src/Console/App.php(93): Craft\PluginsService->loadPlugins()
`