### PR TITLE
Delete old blocktypes from matrixfields on force

### DIFF
--- a/src/Models/AssetsField.php
+++ b/src/Models/AssetsField.php
@@ -52,10 +52,11 @@ class AssetsField extends Field
      * @param FieldModel           $field
      * @param string               $fieldHandle
      * @param FieldGroupModel|null $group
+     * @param bool                 $force
      */
-    public function populate(array $fieldDefinition, FieldModel $field, $fieldHandle, FieldGroupModel $group = null)
+    public function populate(array $fieldDefinition, FieldModel $field, $fieldHandle, FieldGroupModel $group = null, $force = false)
     {
-        parent::populate($fieldDefinition, $field, $fieldHandle, $group);
+        parent::populate($fieldDefinition, $field, $fieldHandle, $group, $force);
 
         $settings = $field->settings;
 

--- a/src/Models/Field.php
+++ b/src/Models/Field.php
@@ -64,8 +64,9 @@ class Field
      * @param FieldModel           $field
      * @param string               $fieldHandle
      * @param FieldGroupModel|null $group
+     * @param bool                 $force
      */
-    public function populate(array $fieldDefinition, FieldModel $field, $fieldHandle, FieldGroupModel $group = null)
+    public function populate(array $fieldDefinition, FieldModel $field, $fieldHandle, FieldGroupModel $group = null, $force = false)
     {
         $field->name = $fieldDefinition['name'];
         $field->handle = $fieldHandle;

--- a/src/Models/PositionSelectField.php
+++ b/src/Models/PositionSelectField.php
@@ -23,10 +23,11 @@ class PositionSelectField extends Field
      * @param FieldModel           $field
      * @param string               $fieldHandle
      * @param FieldGroupModel|null $group
+     * @param bool                 $force
      */
-    public function populate(array $fieldDefinition, FieldModel $field, $fieldHandle, FieldGroupModel $group = null)
+    public function populate(array $fieldDefinition, FieldModel $field, $fieldHandle, FieldGroupModel $group = null, $force = false)
     {
-        parent::populate($fieldDefinition, $field, $fieldHandle, $group);
+        parent::populate($fieldDefinition, $field, $fieldHandle, $group, $force);
 
         $options = [];
         $settings = $fieldDefinition['settings'];

--- a/src/Models/SuperTableField.php
+++ b/src/Models/SuperTableField.php
@@ -60,10 +60,11 @@ class SuperTableField extends MatrixField
     /**
      * @param array      $fieldDefinition
      * @param FieldModel $field
+     * @param bool       $force
      *
      * @return SuperTable_BlockTypeModel[]
      */
-    protected function getBlockTypes(array $fieldDefinition, FieldModel $field)
+    protected function getBlockTypes(array $fieldDefinition, FieldModel $field, $force = false)
     {
         $blockTypes = $this->getSuperTableService()->getBlockTypesByFieldId($field->id);
 

--- a/src/Services/Fields.php
+++ b/src/Services/Fields.php
@@ -148,7 +148,7 @@ class Fields extends Base
 
                     $group = $this->createFieldGroupModel($name);
 
-                    $this->importFields($fieldDefinitions, $group);
+                    $this->importFields($fieldDefinitions, $group, $force);
 
                     $this->commitTransaction();
                 } catch (\Exception $e) {
@@ -284,10 +284,11 @@ class Fields extends Base
      *
      * @param array           $fieldDefinitions
      * @param FieldGroupModel $group
+     * @param bool            $force
      *
      * @throws \Exception
      */
-    private function importFields(array $fieldDefinitions, FieldGroupModel $group)
+    private function importFields(array $fieldDefinitions, FieldGroupModel $group, $force = false)
     {
         $fieldFactory = $this->getFieldFactory();
 
@@ -302,7 +303,7 @@ class Fields extends Base
 
             Craft::log(Craft::t('Importing `{name}`', ['name' => $fieldDef['name']]));
 
-            $schematicFieldModel->populate($fieldDef, $field, $fieldHandle, $group);
+            $schematicFieldModel->populate($fieldDef, $field, $fieldHandle, $group, $force);
             $this->saveFieldModel($field);
         }
     }


### PR DESCRIPTION
If the blocktypes are missing from the definition they should be deleted from the matrix field when --force is used.

I had to add $force to the entire call tree to the `getBlockTypes` function because this was the only place where I saw how to easily implement this, if you know a better way, I'll be happy to use that :)

Fixes #82 