### PR TITLE
Use CRAFT_FRAMEWORK_PATH to locate framework files

### DIFF
--- a/bin/schematic
+++ b/bin/schematic
@@ -70,7 +70,7 @@ require __DIR__.'/../../../autoload.php';
 Yii::$enableIncludePath = false;
 
 // Because CHttpRequest is one of those stupid Yii files that has multiple classes defined in it.
-require_once CRAFT_APP_PATH.'framework/web/CHttpRequest.php';
+require_once CRAFT_FRAMEWORK_PATH.'web/CHttpRequest.php';
 
 // Fake server name on cli
 $_SERVER['SERVER_NAME'] = getenv('CRAFT_SITENAME');

--- a/bin/schematic
+++ b/bin/schematic
@@ -53,7 +53,7 @@ ini_set('display_errors', 1);
 defined('YII_DEBUG') || define('YII_DEBUG', false);
 defined('YII_TRACE_LEVEL') || define('YII_TRACE_LEVEL', 3);
 
-require_once CRAFT_APP_PATH.'framework/yii.php';
+require_once CRAFT_FRAMEWORK_PATH.'yii.php';
 require_once CRAFT_APP_PATH.'Craft.php';
 require_once CRAFT_APP_PATH.'Info.php';
 


### PR DESCRIPTION
The require statement to load `yii.php` depends on a specific directory
structure that assumes the Yii framework is nested within the Craft app
directory. Rather than installing from an archive, I'm installing Craft
via Composer which places it and the Yii framework in their own
directories beneath `vendor`. Using the `CRAFT_FRAMEWORK_PATH` variable
is more reliable for finding the framework code than using
`CRAFT_APP_PATH` as a starting point.