### PR TITLE
Feature/exclude import

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,36 @@ Optionally the `--force` flag can be used to make the import delete any items wh
 
 **WARNING!!** This will also delete any _related_ content.
 
+To skip importing a specific of data type, exclusions can be specified in the following form:
+
+```
+./vendor/bin/schematic import --exclude=assetSources
+```
+
+Multiple exclusions can also be specified:
+
+```
+./vendor/bin/schematic import --exclude=assetSources --exclude=categoryGroups
+```
+
+Here is a list of all of the data types and their corresponding exclude parameter values:
+
+| Data Type | Exlude Parameter |
+| ------------- |-------------|
+| Asset Sources | assetSources |
+| Asset Transforms | assetTransforms |
+| Category Groups | categoryGroups |
+| Element Indexes | elementIndexSettings |
+| Fields | fields |
+| Global Sets | globalSets |
+| Locales | locales |
+| Plugins | plugins |
+| Plugin Data | pluginData |
+| Sections | sections |
+| Tag Groups | tagGroups |
+| Users | users |
+| User Groups | userGroups |
+
 Keys in the schema file can be overridden by passing an override file to schematic using the `--override_file` flag, for instance: `vendor/bin/schematic import --override_file=craft/config/override.yml`.
 
 ### Overrides

--- a/src/ConsoleCommands/ImportCommand.php
+++ b/src/ConsoleCommands/ImportCommand.php
@@ -5,6 +5,7 @@ namespace NerdsAndCompany\Schematic\ConsoleCommands;
 use Craft\Craft;
 use Craft\BaseCommand as Base;
 use Craft\IOHelper;
+use NerdsAndCompany\Schematic\Services\Schematic;
 
 /**
  * Schematic Import Command.
@@ -25,16 +26,45 @@ class ImportCommand extends Base
      * @param string $file          yml file containing the schema definition
      * @param string $override_file yml file containing the override values
      * @param bool   $force         if set to true items not in the import will be deleted
+     * @param array  $exclude       Data to not import
      *
      * @return int
      */
-    public function actionIndex($file = 'craft/config/schema.yml', $override_file = 'craft/config/override.yml', $force = false)
+    public function actionIndex($file = 'craft/config/schema.yml', $override_file = 'craft/config/override.yml', $force = false, array $exclude = null)
     {
         if (!IOHelper::fileExists($file)) {
             $this->usageError(Craft::t('File not found.'));
         }
 
-        $result = Craft::app()->schematic->importFromYaml($file, $override_file, $force);
+        $dataTypes = Schematic::getExportableDataTypes();
+
+        // If there are data exclusions.
+        if ($exclude !== null) {
+            // Find any invalid data to exclude.
+            $invalidExcludes = array_diff($exclude, $dataTypes);
+
+            // If any invalid exclusions were specified.
+            if (count($invalidExcludes) > 0) {
+                $errorMessage = 'Invalid exlude';
+
+                if (count($invalidExcludes) > 1) {
+                    $errorMessage .= 's';
+                }
+
+                $errorMessage .= ': '.implode(', ', $invalidExcludes).'.';
+                $errorMessage .= ' Valid exclusions are '.implode(', ', $dataTypes);
+
+                // Output an error message outlining what invalid exclusions were specified.
+                echo "\n".$errorMessage."\n\n";
+
+                return 1;
+            }
+
+            // Remove any explicitly excluded data types from the list of data types to export.
+            $dataTypes = array_diff($dataTypes, $exclude);
+        }
+
+        $result = Craft::app()->schematic->importFromYaml($file, $override_file, $force, $dataTypes);
 
         if (!$result->hasErrors()) {
             Craft::log(Craft::t('Loaded schema from {file}', ['file' => $file]));

--- a/tests/Services/SchematicTest.php
+++ b/tests/Services/SchematicTest.php
@@ -282,6 +282,25 @@ class SchematicTest extends BaseTest
     }
 
     /**
+     * Test import from yml excluding data types.
+     *
+     * @covers ::exportToYaml
+     */
+    public function testImportFromYamlExcludingDataTypes()
+    {
+        //We do not want to import these DataTypes, so these import functions should not be called.
+        Craft::app()->schematic_users->expects($this->exactly(0))->method('import');
+        Craft::app()->schematic_plugins->expects($this->exactly(0))->method('import');
+
+        //We do want to import these DataTypes, so these import functions should be called.
+        Craft::app()->schematic_userGroups->expects($this->exactly(1))->method('import');
+        Craft::app()->schematic_assetSources->expects($this->exactly(1))->method('import');
+
+        $results = $this->schematicService->importFromYaml($this->getYamlTestFile(), null, false, ['assetSources', 'userGroups']);
+        $this->assertFalse($results->hasErrors());
+    }
+
+    /**
      * @param $service
      *
      * @return Mock


### PR DESCRIPTION
Hi,

I added the exclude flag to the import command, like already exists on the export command. This way keys that are excluded but still present in the export file are ignored.

This way it's possible to do partial imports and also fixes the problem that I had in #105, that deleted my userGroups even though I ignored them because it exports the keys as an empty array.