### PR TITLE
Don’t scrutinize test files

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,9 @@
 checks:
     php:
         code_rating: true
-        duplication: false
+        duplication: true
 tools:
     external_code_coverage: true
+filter:
+    excluded_paths:
+        - tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 # execute tests
 script:
   - ./vendor/bin/phpcs
-  - ./vendor/bin/phpmd src text phpmd.xml --suffixes php
+  - ./vendor/bin/phpmd src,tests text phpmd.xml --suffixes php
   - php vendor/bin/codecept run --coverage --coverage-xml
 
 # upload coverage to scrutinizer

--- a/codeception.yml
+++ b/codeception.yml
@@ -10,6 +10,8 @@ coverage:
     enabled: true
     include:
         - src/*
+    exclude:
+        - src/icon.svg
 actor_suffix: Tester
 extensions:
     enabled:

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -20,4 +20,6 @@
     </properties>
   </rule>
   <rule ref="rulesets/unusedcode.xml"/>
+
+  <exclude-pattern>tests/_support/_generated</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
phpmd and phpcs will have to do
Scrutinizer doesn't seem to be able to handle mock objects very well

Also sneaked in skipping `icon.svg` for test coverage.

- [ ] I updated the changelog
- [ ] I updated the composer.json version
- [ ] I wrote tests
- [x] I am proud of my code
