### PR TITLE
Added ability to inject custom converters with an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.5
+### Added
+- Added ability to inject custom converters
+
 ## 4.0.4 - 2018-04-28
 ### Fixed
 - Fixed a bug where categories field source was not imported

--- a/README.md
+++ b/README.md
@@ -132,7 +132,17 @@ Then the environment variable `SCHEMATIC_KEY_VALUE` needs to be set. The value o
 
 ### Hooks
 
-There are no hooks available at this time.
+Custom converters can be injected with the `EVENT_RESOLVE_CONVERTER` event.
+This can be especially useful for importing and exporting custom field types.
+The converters need to implement the `NerdsAndCompany\Schematic\Interfaces\ConverterInterface`.
+
+```php
+Event::on(Schematic::class, Schematic::EVENT_RESOLVE_CONVERTER, function (ConverterEvent $event) {
+    if ($event->modelClass = "My\Custom\Field") {
+      $event->converterClass = "My\Custom\FieldConverter";
+    }
+});
+```
 
 ### Caveats
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.4",
+    "version": "4.0.5",
     "name": "nerds-and-company/schematic",
     "description": "Craft setup and sync tool",
     "type": "craft-plugin",

--- a/src/Events/ConverterEvent.php
+++ b/src/Events/ConverterEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace NerdsAndCompany\Schematic\Events;
+
+use yii\base\Event;
+
+/**
+ * Schematic Converter Event.
+ *
+ * Sync Craft Setups.
+ *
+ * @author    Nerds & Company
+ * @copyright Copyright (c) 2015-2018, Nerds & Company
+ * @license   MIT
+ *
+ * @see      http://www.nerds.company
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ConverterEvent extends Event
+{
+    /**
+     * @var string
+     */
+    public $modelClass;
+
+    /**
+     * @var string
+     */
+    public $converterClass;
+}

--- a/src/Events/ConverterEvent.php
+++ b/src/Events/ConverterEvent.php
@@ -14,8 +14,6 @@ use yii\base\Event;
  * @license   MIT
  *
  * @see      http://www.nerds.company
- *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ConverterEvent extends Event
 {

--- a/src/Schematic.php
+++ b/src/Schematic.php
@@ -27,6 +27,7 @@ use NerdsAndCompany\Schematic\Mappers\UserSettingsMapper;
 use NerdsAndCompany\Schematic\Interfaces\ConverterInterface;
 use NerdsAndCompany\Schematic\Interfaces\DataTypeInterface;
 use NerdsAndCompany\Schematic\Interfaces\MapperInterface;
+use NerdsAndCompany\Schematic\Events\ConverterEvent;
 
 /**
  * Schematic.
@@ -43,6 +44,8 @@ use NerdsAndCompany\Schematic\Interfaces\MapperInterface;
  */
 class Schematic extends Plugin
 {
+    const EVENT_RESOLVE_CONVERTER = 'resolve_converter';
+
     /**
      * @var string
      */
@@ -169,6 +172,14 @@ class Schematic extends Plugin
         }
 
         $converterClass = 'NerdsAndCompany\\Schematic\\Converters\\'.ucfirst(str_replace('craft\\', '', $modelClass));
+        $event = new ConverterEvent([
+            'modelClass' => $modelClass,
+            'converterClass' => $converterClass,
+        ]);
+
+        $this->trigger(self::EVENT_RESOLVE_CONVERTER, $event);
+        $converterClass = $event->converterClass;
+
         if (class_exists($converterClass)) {
             $converter = new $converterClass();
             if ($converter instanceof ConverterInterface) {


### PR DESCRIPTION
- [x] I updated the changelog
- [x] I updated the composer.json version
- [ ] I wrote tests
- [x] I am proud of my code

Custom converters can be injected with the `EVENT_RESOLVE_CONVERTER` event.
This can be especially useful for importing and exporting custom field types.
The converters need to implement the `NerdsAndCompany\Schematic\Interfaces\ConverterInterface`.

```php
Event::on(Schematic::class, Schematic::EVENT_RESOLVE_CONVERTER, function (ConverterEvent $event) {
    if ($event->modelClass = "My\Custom\Field") {
      $event->converterClass = "My\Custom\FieldConverter";
    }
});
```

Fixes #123 