### PR TITLE
Schematic now also uses the override file when exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 4.0.8
+## 4.0.8 - 2018-06-01
 ### Added
-- Schematic now also uses the override file when exporting
+- Schematic now also uses the override file when exporting, fixing #48
 
 ## 4.0.7 - 2018-05-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.8
+### Added
+- Schematic now also uses the override file when exporting
+
 ## 4.0.7 - 2018-05-22
 ### Fixed
 - Fixed issues with importing element index settings

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.7",
+    "version": "4.0.8",
     "name": "nerds-and-company/schematic",
     "description": "Craft setup and sync tool",
     "type": "craft-plugin",

--- a/src/Controllers/ExportController.php
+++ b/src/Controllers/ExportController.php
@@ -45,7 +45,12 @@ class ExportController extends Base
             $result[$dataTypeHandle] = $this->module->$mapper->export($records);
         }
 
-        FileHelper::writeToFile($this->file, Data::toYaml($result));
+        $yamlOverride = null;
+        if (file_exists($this->overrideFile)) {
+            $yamlOverride = file_get_contents($this->overrideFile);
+        }
+
+        FileHelper::writeToFile($this->file, Data::toYaml($result, $yamlOverride));
         Schematic::info('Exported schema to '.$this->file);
 
         return 0;

--- a/src/Models/Data.php
+++ b/src/Models/Data.php
@@ -76,12 +76,20 @@ class Data extends Model
     /**
      * Convert array to yaml.
      *
-     * @param array $data
+     * @param array  $data
+     * @param string $overrideYaml
      *
      * @return string
      */
-    public static function toYaml(array $data): string
+    public static function toYaml(array $data, $overrideYaml = ''): string
     {
+        if (!empty($overrideYaml)) {
+            $overrideData = Yaml::parse($overrideYaml);
+            if (null != $overrideData) {
+                $data = array_replace_recursive($data, $overrideData);
+            }
+        }
+
         return Yaml::dump($data, 12, 2);
     }
 }

--- a/tests/_data/test_override.yml
+++ b/tests/_data/test_override.yml
@@ -2,4 +2,4 @@ volumes:
   uploads:
     attributes:
       keyId: override_key
-      bucket: %s3_bucket%
+      bucket: '%s3_bucket%'

--- a/tests/unit/Models/DataTest.php
+++ b/tests/unit/Models/DataTest.php
@@ -79,4 +79,12 @@ class DataTest extends Unit
         $yaml = Data::toYaml($dataModel);
         $this->assertContains('override_bucket_name', $yaml);
     }
+
+    public function testToYamlOverride()
+    {
+        $dataModel = $this->generateDataModel();
+        $override = $this->getOverrideTestFile();
+        $yaml = Data::toYaml($dataModel, $override);
+        $this->assertContains("'%s3_bucket%'", $yaml);
+    }
 }


### PR DESCRIPTION
- [x] I updated the changelog
- [x] I updated the composer.json version
- [x] I wrote tests
- [x] I am proud of my code

Fixes #48 