### PR TITLE
Schematic now recursively parses source id's to handles and vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 4.0.9
+### Added
+- Schematic now recursively parses source id's to handles and vice versa
+
 ## 4.0.8 - 2018-06-01
 ### Added
 - Schematic now also uses the override file when exporting

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.8",
+    "version": "4.0.9",
     "name": "nerds-and-company/schematic",
     "description": "Craft setup and sync tool",
     "type": "craft-plugin",

--- a/src/Behaviors/SourcesBehavior.php
+++ b/src/Behaviors/SourcesBehavior.php
@@ -22,6 +22,30 @@ use NerdsAndCompany\Schematic\Schematic;
 class SourcesBehavior extends Behavior
 {
     /**
+     * Recursively find sources in definition attributes.
+     *
+     * @param string $fieldType
+     * @param array  $attributes
+     * @param string $indexFrom
+     * @param string $indexTo
+     *
+     * @return array
+     */
+    public function findSources(string $fieldType, array $attributes, string $indexFrom, string $indexTo): array
+    {
+        foreach ($attributes as $key => $attribute) {
+            if ($key === 'source' || $key === 'sources') {
+                $method = 'get'.ucfirst($key);
+                $attributes[$key] = $this->$method($fieldType, $attribute, $indexFrom, $indexTo);
+            } elseif (is_array($attribute)) {
+                $attributes[$key] = $this->findSources($fieldType, $attribute, $indexFrom, $indexTo);
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
      * Get sources based on the indexFrom attribute and return them with the indexTo attribute.
      *
      * @param string       $fieldType
@@ -60,7 +84,7 @@ class SourcesBehavior extends Behavior
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function getSource(string $fieldType, string $source, string $indexFrom, string $indexTo)
+    public function getSource(string $fieldType, $source, string $indexFrom, string $indexTo)
     {
         if (false === strpos($source, ':')) {
             return $source;

--- a/src/Behaviors/SourcesBehavior.php
+++ b/src/Behaviors/SourcesBehavior.php
@@ -34,9 +34,10 @@ class SourcesBehavior extends Behavior
     public function findSources(string $fieldType, array $attributes, string $indexFrom, string $indexTo): array
     {
         foreach ($attributes as $key => $attribute) {
-            if ($key === 'source' || $key === 'sources') {
-                $method = 'get'.ucfirst($key);
-                $attributes[$key] = $this->$method($fieldType, $attribute, $indexFrom, $indexTo);
+            if ($key === 'source') {
+                $attributes[$key] = $this->getSource($fieldType, $attribute, $indexFrom, $indexTo);
+            } elseif ($key === 'sources') {
+                $attributes[$key] = $this->getSources($fieldType, $attribute, $indexFrom, $indexTo);
             } elseif (is_array($attribute)) {
                 $attributes[$key] = $this->findSources($fieldType, $attribute, $indexFrom, $indexTo);
             }
@@ -84,7 +85,7 @@ class SourcesBehavior extends Behavior
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function getSource(string $fieldType, $source, string $indexFrom, string $indexTo)
+    public function getSource(string $fieldType, string $source = null, string $indexFrom, string $indexTo)
     {
         if (false === strpos($source, ':')) {
             return $source;

--- a/src/Converters/Models/Base.php
+++ b/src/Converters/Models/Base.php
@@ -94,15 +94,7 @@ abstract class Base extends BaseComponent implements ConverterInterface
     public function setRecordAttributes(Model &$record, array $definition, array $defaultAttributes)
     {
         // Set sources
-        if (isset($definition['attributes']['sources'])) {
-            $sources = $this->getSources($definition['class'], $definition['attributes']['sources'], 'handle', 'id');
-            $definition['attributes']['sources'] = $sources;
-        }
-
-        if (isset($definition['attributes']['source'])) {
-            $source = $this->getSource($definition['class'], $definition['attributes']['source'], 'handle', 'id');
-            $definition['attributes']['source'] = $source;
-        }
+        $definition['attributes'] = $this->findSources($definition['class'], $definition['attributes'], 'handle', 'id');
 
         $attributes = array_merge($definition['attributes'], $defaultAttributes);
         $record->setAttributes($attributes, false);

--- a/src/Converters/Models/Base.php
+++ b/src/Converters/Models/Base.php
@@ -67,15 +67,7 @@ abstract class Base extends BaseComponent implements ConverterInterface
         unset($definition['attributes']['dateUpdated']);
 
         // Define sources
-        if (isset($definition['attributes']['sources'])) {
-            $sources = $this->getSources($definition['class'], $definition['attributes']['sources'], 'id', 'handle');
-            $definition['attributes']['sources'] = $sources;
-        }
-
-        if (isset($definition['attributes']['source'])) {
-            $source = $this->getSource($definition['class'], $definition['attributes']['source'], 'id', 'handle');
-            $definition['attributes']['source'] = $source;
-        }
+        $definition['attributes'] = $this->findSources($definition['class'], $definition['attributes'], 'id', 'handle');
 
         // Define field layout
         if (isset($definition['attributes']['fieldLayoutId'])) {


### PR DESCRIPTION
- [x] I updated the changelog
- [x] I updated the composer.json version
- [ ] I wrote tests
- [x] I am proud of my code
