### PR TITLE
Default to empty array if settingsModel is broken

### DIFF
--- a/src/Mappers/PluginMapper.php
+++ b/src/Mappers/PluginMapper.php
@@ -51,7 +51,7 @@ class PluginMapper extends BaseComponent implements MapperInterface
         return [
           'isEnabled' => $pluginInfo['isEnabled'],
           'isInstalled' => $pluginInfo['isInstalled'],
-          'settings' => $settings ? $settings->attributes : [],
+          'settings' => $settings->attributes ?? [],
         ];
     }
 


### PR DESCRIPTION
If the settingsmodel is broken , default to an empty array.

This is  workaround for the Ansel plugin which returns a Noop class instead of a proper settings model, which causes an ErrorException to be thrown.


![image](https://user-images.githubusercontent.com/1089652/42322692-b123a34c-805d-11e8-9a00-c11c735323b5.png)


From Ansel.php
```php

    /**
     * We have to have this here because reasons (Craft has its faults)
     */
    public function createSettingsModel()
    {
        return new Noop();
    }

```


the Noop class causing an error exception if you try to export it's plugin settings.
```php
<?php

namespace buzzingpixel\ansel;

class Noop
{
  
    public function __call(string $name, array $args)
    {
        return null;
    }
}

```

