### PR TITLE
Fix assignUserGroup permission serialization bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.8.9 ###
+- Fixed assignUserGroup permission serialization bug
+
 ### 3.8.8 ###
 - Added ability to exclude datatypes on import (thanks @Zae)
 

--- a/src/Services/Sources.php
+++ b/src/Services/Sources.php
@@ -110,6 +110,10 @@ class Sources extends BaseApplication
               break;
           case 'editLocale':
               return $source;
+          case 'assignUserGroup':
+              $service = Craft::app()->userGroups;
+              $method = 'getGroupBy';
+              break;
        }
 
        if (isset($service) && isset($method) && isset($sourceFrom)) {


### PR DESCRIPTION
The assignUserGroup permission was being serialized as an empty string, now it will serialize as 'assignUserGroup:<groupname>' and correctly import.

Fixes #150 

- [x]  I updated the changelog
- [ ] I updated the composer.json version
- [ ] I wrote tests
- [x] I am proud of my code

I could not get the testsuite to work on my local environment so sadly I did not add any tests.
