### PR TITLE
Schematic can now parse environment variables in the schema file dire…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.15 - 2018-08-21
+### Added
+- Schematic can now parse environment variables in the schema file directly, without need for an override file
+- Used environment variables don't have to be prefixed with SCHEMATIC_ anymore
+- Environment variables without SCHEMATIC_ prefix are now case-sensitive
+
 ## 4.0.14 - 2018-07-26
 ### Fixed
 - Fixed a bug where element indexes with custom elements failed to import

--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ Multiple exclusions can also be specified:
 ./craft schematic/import --exclude=volumes,categoryGroups
 ```
 
-Keys in the schema file can be overridden by passing an override file to schematic using the `--override-file` flag, for instance: `./craft schematic/import --override-file=craft/config/override.yml`.
-
 See [Supported DataTypes](#Supported DataTypes)
 
 ### Supported DataTypes
@@ -116,9 +114,11 @@ Here is a list of all of the data types and their corresponding exclude paramete
 | User Groups | userGroups |
 | Volumes | volumes |
 
-### Overrides
+### Overrides and environment variables
 
-Specific keys can be overriden by adding a key in `craft/config/override.yml` and setting the corresponding environment variable. The key name in the `override.yml` needs to be the same as the key you want to override from `schema.yml`, including any parent key names. The value has to start and end with a `%` (percentage sign). The correspending environment value will be `SCHEMATIC_{value_without_percentage_signs}`.
+Specific keys can be overriden by adding a key in `config/override.yml` and setting the corresponding environment variable. The key name in the `override.yml` needs to be the same as the key you want to override from `schema.yml`, including any parent key names.
+
+The override file is also applied back when exporting, so your variables are not overriden by actual values. Schematic also supports passing an override file using the `--override-file` flag, for instance: `./craft schematic/import --override-file=path/to/your/config/override.yml`.
 
 #### Example
 
@@ -126,10 +126,12 @@ If the following `override.yml` is defined:
 
 ```yml
 parent:
-    key_name: %key_value%
+    key_name: %KEY_VALUE%
 ```
 
-Then the environment variable `SCHEMATIC_KEY_VALUE` needs to be set. The value of this environment variable will override the key `key_name`. If the environment variable is not set Schematic will throw an error.
+Then the environment variable `KEY_VALUE` needs to be set. The value of this environment variable will override the key `key_name`. If the environment variable is not set Schematic will throw an error.
+
+Environment variables can also directly be used in the `schema.yml` file. Beware that if you do that, they will be overriden on export by their environment variable's values.
 
 ### Hooks
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.14",
+    "version": "4.0.15",
     "name": "nerds-and-company/schematic",
     "description": "Craft setup and sync tool",
     "type": "craft-plugin",
@@ -13,8 +13,8 @@
         },
         {
             "name": "Bob Olde Hampsink",
-            "email": "b.oldehampsink@nerds.company",
-            "homepage": "https://nerds.company",
+            "email": "bob@robuust.digital",
+            "homepage": "https://robuust.digital",
             "role": "Developer"
         }
     ],

--- a/src/Models/Data.php
+++ b/src/Models/Data.php
@@ -29,11 +29,14 @@ class Data extends Model
      */
     public static function fromYaml($yaml, $overrideYaml): array
     {
+        $yaml = static::replaceEnvVariables($yaml);
         $data = Yaml::parse($yaml);
+
         if (!empty($overrideYaml)) {
             $overrideYaml = static::replaceEnvVariables($overrideYaml);
             $overrideData = Yaml::parse($overrideYaml);
-            if (null != $overrideData) {
+
+            if ($overrideData != null) {
                 $data = array_replace_recursive($data, $overrideData);
             }
         }
@@ -61,11 +64,15 @@ class Data extends Model
         $originalValues = $matches[0];
         $replaceValues = [];
         foreach ($originalValues as $match) {
-            $envVariable = strtoupper(substr($match, 1, -1));
-            $envVariable = 'SCHEMATIC_'.$envVariable;
+            $envVariable = substr($match, 1, -1);
             $envValue = getenv($envVariable);
             if (!$envValue) {
-                throw new Exception("Schematic environment variable not set: {$envVariable}");
+                $envVariable = strtoupper($envVariable);
+                $envVariable = 'SCHEMATIC_'.$envVariable;
+                $envValue = getenv($envVariable);
+                if (!$envValue) {
+                    throw new Exception("Schematic environment variable not set: {$envVariable}");
+                }
             }
             $replaceValues[] = $envValue;
         }
@@ -85,7 +92,8 @@ class Data extends Model
     {
         if (!empty($overrideYaml)) {
             $overrideData = Yaml::parse($overrideYaml);
-            if (null != $overrideData) {
+
+            if ($overrideData != null) {
                 $data = array_replace_recursive($data, $overrideData);
             }
         }

--- a/tests/_data/test_override.yml
+++ b/tests/_data/test_override.yml
@@ -2,4 +2,4 @@ volumes:
   uploads:
     attributes:
       keyId: override_key
-      bucket: '%s3_bucket%'
+      bucket: '%S3_BUCKET%'

--- a/tests/_data/test_override.yml
+++ b/tests/_data/test_override.yml
@@ -3,3 +3,4 @@ volumes:
     attributes:
       keyId: override_key
       bucket: '%S3_BUCKET%'
+      secret: '%s3_secret_access_key%'

--- a/tests/_data/test_schema.yml
+++ b/tests/_data/test_schema.yml
@@ -2,7 +2,7 @@ volumes:
   uploads:
     attributes:
       keyId: original_key_id
-      bucket: original_bucket_name
+      bucket: '%S3_BUCKET%'
 users:
   settings:
     requireEmailVerification: true

--- a/tests/_data/test_schema.yml
+++ b/tests/_data/test_schema.yml
@@ -3,6 +3,7 @@ volumes:
     attributes:
       keyId: original_key_id
       bucket: '%S3_BUCKET%'
+      secret: '%s3_secret_access_key%'
 users:
   settings:
     requireEmailVerification: true

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -47,7 +47,7 @@ class Unit extends Module
     {
         $mockApp = $this->getMockApp($test);
         $mockApp->controller = $this->getMock($test, Controller::class);
-        $mockApp->controller->module = $this->getmockModule($test);
+        $mockApp->controller->module = $this->getMockModule($test);
 
         Craft::$app = $mockApp;
         Schematic::$force = false;

--- a/tests/unit/Models/DataTest.php
+++ b/tests/unit/Models/DataTest.php
@@ -39,6 +39,8 @@ class DataTest extends Unit
      */
     private function generateDataModel($useOverride = false)
     {
+        putenv('SCHEMATIC_S3_SECRET_ACCESS_KEY=secret');
+
         $schema = $this->getSchemaTestFile();
         $override = $useOverride ? $this->getOverrideTestFile() : [];
 
@@ -58,6 +60,7 @@ class DataTest extends Unit
         putenv('SCHEMATIC_S3_BUCKET=bucket_name');
         $result = $this->generateDataModel();
         $this->assertEquals('bucket_name', $result['volumes']['uploads']['attributes']['bucket']);
+        $this->assertEquals('secret', $result['volumes']['uploads']['attributes']['secret']);
     }
 
     public function testRegularOverride()
@@ -80,6 +83,7 @@ class DataTest extends Unit
         putenv('SCHEMATIC_S3_BUCKET=override_bucket_name');
         $result = $this->generateDataModel(true);
         $this->assertEquals('override_bucket_name', $result['volumes']['uploads']['attributes']['bucket']);
+        $this->assertEquals('secret', $result['volumes']['uploads']['attributes']['secret']);
     }
 
     public function testErrorWhenEnvironmentVariableNotSet()


### PR DESCRIPTION
- Schematic can now parse environment variables in the schema file directly, without need for an override file
- Used environment variables don't have to be prefixed with SCHEMATIC_ anymore
- Environment variables without SCHEMATIC_ prefix are now case-sensitive

This is handy for Heroku add-ons which define their own env vars that you don't want to copy over manually to `SCHEMATIC_` vars all the time. This makes it more useful for PR apps as well.

- [x] I updated the changelog
- [x] I updated the composer.json version
- [x] I wrote tests
- [x] I am proud of my code

@bvangennep @gijsstegehuis 