### PR TITLE
- Lock Schematic for use with Craft 3.0.x - it doesn't work with Craf…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1 - 2019-01-22
+### Changed
+- Lock Schematic for use with Craft 3.0.x - it doesn't work with Craft 3.1.x
+
 ## 4.1.0 - 2018-11-19
 ### Added
 - Added more flexibility for getting a record's index

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.1.0",
+    "version": "4.1.1",
     "name": "nerds-and-company/schematic",
     "description": "Craft setup and sync tool",
     "type": "craft-plugin",
@@ -30,7 +30,7 @@
     },
     "require": {
         "php": "^7.0",
-        "craftcms/cms": "^3.0",
+        "craftcms/cms": "~3.0.0",
         "symfony/yaml": "^3.0 || ^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
…t 3.1.x

- [x] I updated the changelog
- [x] I updated the composer.json version
- [ ] I wrote tests
- [ ] I am proud of my code
